### PR TITLE
Color for fdT plotting + surveys renumbered for CETA

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -75,6 +75,7 @@ The following lists the main package functions, grouped by analysis framework:
 | `cycleShifts()` |  Estimates cyclical shifts (i.e. advances or delays). |
 | `cycleConvexity()` |  Estimates the degree of convexity of cycles.     |
 | `cyclePCoA()` | Performs Principal Coordinates Analysis and draws cycles in the ordination scatter plot.    |
+| `fixedDateTrajectoryPCoA()` | Performs Principal Coordinates Analysis and draws fixed date trajectories in the ordination scatter plot.    |
 
 **Functions for Ecological Quality Assessment (EQA)**
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ framework:
 | `cycleShifts()` | Estimates cyclical shifts (i.e. advances or delays). |
 | `cycleConvexity()` | Estimates the degree of convexity of cycles. |
 | `cyclePCoA()` | Performs Principal Coordinates Analysis and draws cycles in the ordination scatter plot. |
+| `fixedDateTrajectoryPCoA()` | Performs Principal Coordinates Analysis and draws fixed date trajectories in the ordination scatter plot. |
 
 **Functions for Ecological Quality Assessment (EQA)**
 

--- a/man/trajectoryCyclical.Rd
+++ b/man/trajectoryCyclical.Rd
@@ -74,6 +74,7 @@ Function \code{extractCycles} returns the base information needed to describe cy
 \itemize{
 \item{\code{sites}: the sites associated to  each ecological states.}
 \item{\code{Cycles}: the names of the cycle each ecological states belongs to. The cycle name is built by combining the site name with C1, C2, C3... in chronological order.}
+\item{\code{surveys}: renumbering of the surveys to describe individual Cycles.}
 \item{\code{times}: the times associated to each ecological states.}
 \item{\code{internal}: a boolean vector with \code{TRUE} indicating "internal" ecological states whereas \code{FALSE} indicates "external" ecological states. This has important implications for the use of \code{extractCycles} outputs (see details).}
 \item{\code{dates}: the dates associated to each ecological states.}
@@ -89,6 +90,7 @@ Function \code{extractFixedDateTrajectories} returns the base information needed
 \itemize{
 \item{\code{sites}: the sites to  each ecological states.}
 \item{\code{fdT}: the names of the fixed-date trajectory each ecological states belongs to. The fixed-date trajectory name is built by combining the site name with "fdT" and the name of the fixed date (from \code{namesFixedDate}).}
+\item{\code{surveys}: renumbering of the surveys to describe individual fixed date trajectories.}
 \item{\code{times}: the times associated to each ecological states.}
 \item{\code{dates}: the dates associated to each ecological states.}
 }
@@ -123,8 +125,8 @@ We recommend reading the vignette on CETA prior to use it.The CETA functions pro
 \details{
 CETA functions:
 \itemize{
-\item{Function \code{extractCycles} reformats a dataset describing one or more cyclical trajectories for the analysis of their cycles.}
-\item{Function \code{extractFixedDateTrajectories} reformats a dataset describing one or more cyclical trajectories for the analysis of their fixed-date trajectories.}
+\item{Function \code{extractCycles} reformats an object of class \code{\link{trajectories}} describing one or more cyclical trajectories into a new object of class \code{\link{trajectories}} designed for the analysis cycles.}
+\item{Function \code{extractFixedDateTrajectories} reformats an object of class \code{\link{trajectories}} describing one or more cyclical trajectories into a new object of class \code{\link{trajectories}} designed for the analysis fixed-date trajectories.}
 \item{Function \code{cycleConvexity} computes the "convexity" of the cycles embedded in one or more cyclical trajectories.}
 \item{Function \code{cycleShifts} computes the cyclical shifts (i.e. advances and delays) that can be obtain from one or more cyclical trajectories.}
 }

--- a/man/trajectoryCyclicalPlots.Rd
+++ b/man/trajectoryCyclicalPlots.Rd
@@ -5,6 +5,7 @@
 \alias{trajectoryCyclicalPlots}
 \alias{cyclePCoA}
 \alias{fixedDateTrajectoryPCoA}
+\alias{customCircularPalette}
 \title{Cyclical trajectory plots}
 \usage{
 cyclePCoA(
@@ -17,7 +18,8 @@ cyclePCoA(
 )
 
 fixedDateTrajectoryPCoA(
-  inputFixedDateTrajectoryPCoA,
+  x,
+  fixedDates.colors = NULL,
   sites.lty = NULL,
   print.names = FALSE,
   axes = c(1, 2),
@@ -25,7 +27,7 @@ fixedDateTrajectoryPCoA(
 )
 }
 \arguments{
-\item{x}{The output of function \code{\link{extractCycles}}.}
+\item{x}{The full output of function \code{\link{extractCycles}} or \code{\link{extractFixedDateTrajectories}} as appropriate, an object of class \code{\link{trajectories}}.}
 
 \item{centered}{Boolean. Have the cycles been centered? Default to FALSE.}
 
@@ -37,9 +39,9 @@ fixedDateTrajectoryPCoA(
 
 \item{...}{Additional parameters for function \code{\link{arrows}}.}
 
-\item{inputFixedDateTrajectoryPCoA}{The full output of function \code{\link{extractFixedDateTrajectories}}.}
+\item{fixedDates.colors}{The colors applied to the different fixed dates trajectories. Defaults to a simple RGB circular color palette.}
 
-\item{sites.lty}{The line type for the different sites (see \code{\link{par}}, \code{"lty"}). The fixed-date trajectories will be distinguished by a default circular color palette.}
+\item{sites.lty}{The line type for the different sites (see \code{\link{par}}, \code{"lty"}).}
 }
 \value{
 Functions \code{cyclePCoA} and \code{fixedDateTrajectoryPCoA} return the results of calling of \code{\link{cmdscale}}.
@@ -49,14 +51,13 @@ Set of plotting functions for Cyclical Ecological Trajectory Analysis:
 }
 \details{
 \itemize{
-\item{Function \code{cyclePCoA} performs principal coordinates analysis (\code{\link{cmdscale}}) and draws trajectories in the ordination scatterplot.}
-\item{Function \code{fixedDateTrajectoryPCoA} performs principal coordinates analysis (\code{\link{cmdscale}}) and draws trajectories in the ordination scatterplot.}
+\item{Function \code{cyclePCoA} removes unwanted points (see details) and performs principal coordinates analysis (\code{\link{cmdscale}}) and draws cycles in the ordination scatterplot.}
+\item{Function \code{fixedDateTrajectoryPCoA} performs principal coordinates analysis (\code{\link{cmdscale}}) and draws fixed date trajectories in the ordination scatterplot.}
 }
 
 The functions \code{cyclePCoA} and \code{fixedDateTrajectoryPCoA} give adapted graphical representation of cycles and fixed-date trajectories respectively using principal coordinate analysis (PCoA, see \code{\link{cmdscale}}).
-Function \code{cyclePCoA} handles external and potential interpolated ecological states so that they are correctly taken in account in PCoA (i.e. avoiding duplication, and reducing the influence of interpolated ecological states as much as possible). In case of centered cycles, the influence of these point will grow as they will not correspond to duplications anymore.
+Function \code{cyclePCoA} handles external and potential interpolated ecological states so that they are correctly taken in account in PCoA (i.e. avoiding duplication, and reducing the influence of interpolated ecological states as much as possible). In case of centered cycles, the influence of these ecological states will grow as they will not correspond to duplications anymore.
 In case of centered cycles, the intended use is to set the parameter \code{centered} to \code{TRUE}.
-Function \code{fixedDateTrajectoryPCoA} has no flexibility for the colors as it defaults to a circular color palette adapted to representation of cyclical processes.
 }
 \seealso{
 \code{\link{trajectoryCyclical}}, \code{\link{cmdscale}}

--- a/man/trajectorySections.Rd
+++ b/man/trajectorySections.Rd
@@ -39,7 +39,8 @@ Function \code{extractTrajectorySections} returns the base information needed to
 \item{\code{metadata}: an object of class \code{\link{data.frame}} describing the ecological states in \code{d} with columns:
 \itemize{
 \item{\code{sites}: the sites associated to each ecological states.}
-\item{\code{TrajSec}: the names of the trajectory sections each ecological states belongs to.}
+\item{\code{sections}: the names of the trajectory sections each ecological states belongs to.}
+\item{\code{surveys}: renumbering of the surveys to describe individual trajectory sections.}
 \item{\code{times}: the times associated to each ecological states.}
 \item{\code{internal}: a boolean vector with \code{TRUE} indicating "internal" ecological states whereas \code{FALSE} indicates "external" ecological states. This has important implications for the use of \code{extractTrajectorySections} outputs (see details).}
 }
@@ -55,7 +56,7 @@ Trajectory sections are flexible way to cut longer trajectories. They are presen
 \details{
 Trajectory sections functions:
 \itemize{
-\item{Function \code{extractTrajectorySections} reformats a dataset describing one or more trajectories into specified trajectory sections. Trajectory sections represent a way to subset trajectories flexibly. Cycles (see CETA documentation) are a particular case of trajectory sections.}
+\item{Function \code{extractTrajectorySections} reformats an object of class \code{\link{trajectories}} describing one or more trajectories into another object of class \code{\link{trajectories}} describing specified trajectory sections. Trajectory sections represent a way to subset trajectories flexibly. Cycles (see \code{\link{extractCycles}}) are a particular case of trajectory sections.}
 \item{Function \code{interpolateEcolStates} compute interpolated ecological states and the new distance matrix associated (used in extractTrajectorySections).}
 }
 

--- a/vignettes/IntroductionCETA.Rmd
+++ b/vignettes/IntroductionCETA.Rmd
@@ -30,7 +30,9 @@ By "regular cyclical dynamics" we mean cycles that are ‒ *most often* ‒ the 
 In this vignette you will learn how to use the specific functions designed for CETA, and how to combine them with the wider ETA framework to obtain metrics describing cyclical trajectories.  
 Let's first call the package:
 ```{r}
-library(ecotraj)
+#library(ecotraj)
+library(devtools)
+load_all("C:/Users/djeghri/Documents/GitHub/ecotraj")
 ```
 
 ## 2. General approach of CETA
@@ -107,7 +109,7 @@ head(fdtrajToy$metadata)
 ```
 The column `fdT` (for fixed-date trajectories) indicates to which fixed-date trajectories the different ecological states in `d` belong. The names in `fdT` are built by concatenating the site (especially useful if several cyclical trajectory are studied in parallel) with the string `fdT` and the name given as argument in `extractFixedDateTrajectories()` (if not provided, the date is used as default).
 
-Using a combination a the new distance matrix `d` and it's descriptors in `metadata`, the output of `extractFixedDateTrajectories()` can be fed in other ETA functions to study fixed-date trajectories. Whenever they identify the input object as one of class `fd.trajectories`, they use the values of `fdT` column as substitute for `sites`. For instance we can visualize the fixed-date trajectories using `trajectoryPCoA()` as follows:
+Using a combination a the new distance matrix `d` and its descriptors in `metadata`, the output of `extractFixedDateTrajectories()` can be fed in other ETA functions to study fixed-date trajectories. Whenever they identify the input object as one of class `fd.trajectories`, they use the values of `fdT` column as substitute for `sites`. For instance we can visualize the fixed-date trajectories using `trajectoryPCoA()` as follows:
 ```{r fig = TRUE, fig.height=5, fig.width=5, fig.align = "center"}
 trajectoryPCoA(fdtrajToy,
                lwd = 2,length = 0.2,


### PR DESCRIPTION
The function fixedDateTrajectoryPCoA does not calls cmocean anymore, instead it build a little home made circular color palette (new internal function "customCircularPalette"). The functions also allows the user to determine the colors. Surveys have been added in all CETA extract functions outputs. Those surveys are a renumbering of the ones used for the original trajectories. Plenty of small documentation updates have been made