### PR TITLE
Examples for CETA + bug fix for sections

### DIFF
--- a/R/trajectoryCyclical.R
+++ b/R/trajectoryCyclical.R
@@ -92,6 +92,50 @@
 #' 
 #' @author Nicolas Djeghri, UBO
 #' @author Miquel De \enc{Cáceres}{Caceres}, CREAF
+#' 
+#' @seealso \code{\link{trajectoryCyclicalPlots}}
+#' 
+#' @examples
+#' #First build a toy dataset
+#' timesToy <- 0:30 #The sampling times of the time series
+#' cycleDurationToy <- 10 #The duration of the cycles (i.e. the periodicity of the time series)
+#' sitesToy <- rep(c("A"),length(timesToy)) #The sites sampled (only one named "A")
+#' trend <- 0.05 #this term will act as a trend displacing the regular cycles
+#' 
+#' #Build cyclical data (note that we apply the trend only to x):
+#' x <- sin((timesToy*2*pi)/cycleDurationToy)+trend*timesToy
+#' y <- cos((timesToy*2*pi)/cycleDurationToy)
+#' matToy <- cbind(x,y)
+#' 
+#' #And express it as a distances:
+#' dToy <- dist(matToy)
+#' 
+#' #Make it an object of class trajectory:
+#' cyclicalTrajToy <- defineTrajectories(d = dToy, sites = sitesToy, times = timesToy)
+#' 
+#' #At this stage, cycles and / or fixed date trajectories are not isolated.
+#' #This done with the two CETA "extract" functions:
+#' cyclesToy <- extractCycles(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+#' fdTrajToy <- extractFixedDateTrajectories(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+#' 
+#' #The output of these functions can be used as input for other ETA functions to get metrics of interest
+#' #such as trajectory length:
+#' trajectoryLengths(x = cyclesToy)
+#' trajectoryLengths(x = fdTrajToy)
+#' 
+#' #or distances between trajectories:
+#' trajectoryDistances(x = cyclesToy)
+#' trajectoryDistances(x = fdTrajToy)
+#' 
+#' #In addition CETA adds two additional specific metrics (cycle convexity, and computation of cyclical shifts).
+#' #For reasons explain above, they require the same inputs as function extractCycles():
+#' cycleConvexity(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+#' #By the way, it is expect to get a NA with the first cycle in this example,
+#' #Cycle convexity cannot be computed right at the start or end of the time series
+#' cycleShifts(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+#' #Note that because our cycles are perfectly regular here, the cyclicalShift computed are all 0 (or close because of R's computing approximations)
+#' 
+#'
 #'
 #' @rdname trajectoryCyclical
 #' @param x An object of class \code{\link{trajectories}} describing a cyclical trajectory.

--- a/R/trajectoryCyclicalPlots.R
+++ b/R/trajectoryCyclicalPlots.R
@@ -26,6 +26,33 @@
 #' 
 #' @seealso \code{\link{trajectoryCyclical}}, \code{\link{cmdscale}}
 #' 
+#' 
+#' @examples
+#' #First build a toy dataset
+#' timesToy <- 0:30 #The sampling times of the time series
+#' cycleDurationToy <- 10 #The duration of the cycles (i.e. the periodicity of the time series)
+#' sitesToy <- rep(c("A"),length(timesToy)) #The sites sampled (only one named "A")
+#' trend <- 0.05 #this term will act as a trend displacing the regular cycles
+#' 
+#' #Build cyclical data (note that we apply the trend only to x):
+#' x <- sin((timesToy*2*pi)/cycleDurationToy)+trend*timesToy
+#' y <- cos((timesToy*2*pi)/cycleDurationToy)
+#' matToy <- cbind(x,y)
+#' 
+#' #And express it as a distances:
+#' dToy <- dist(matToy)
+#' 
+#' #Make it an object of class trajectory:
+#' cyclicalTrajToy <- defineTrajectories(d = dToy, sites = sitesToy, times = timesToy)
+#' 
+#' #And extract the cycles and fixed date trajectories:
+#' cyclesToy <- extractCycles(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+#' fdTrajToy <- extractFixedDateTrajectories(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+#' 
+#' #CETA plotting functions take the outputs of CETA extract functions as inputs:
+#' cyclePCoA(cyclesToy)
+#' fixedDateTrajectoryPCoA(fdTrajToy)
+#' 
 #' @rdname trajectoryCyclicalPlots
 #' @param x The full output of function \code{\link{extractCycles}} or \code{\link{extractFixedDateTrajectories}} as appropriate, an object of class \code{\link{cycles}} or \code{\link{fd.trajectories}}.
 #' @param centered Boolean. Have the cycles been centered? Default to FALSE.

--- a/man/trajectoryCyclical.Rd
+++ b/man/trajectoryCyclical.Rd
@@ -154,6 +154,52 @@ Note: Function \code{cycleShifts} is computation intensive for large data sets, 
 
 Further information and detailed examples of the use of CETA functions can be found in the associated vignette.
 }
+\examples{
+#First build a toy dataset
+timesToy <- 0:30 #The sampling times of the time series
+cycleDurationToy <- 10 #The duration of the cycles (i.e. the periodicity of the time series)
+sitesToy <- rep(c("A"),length(timesToy)) #The sites sampled (only one named "A")
+trend <- 0.05 #this term will act as a trend displacing the regular cycles
+
+#Build cyclical data (note that we apply the trend only to x):
+x <- sin((timesToy*2*pi)/cycleDurationToy)+trend*timesToy
+y <- cos((timesToy*2*pi)/cycleDurationToy)
+matToy <- cbind(x,y)
+
+#And express it as a distances:
+dToy <- dist(matToy)
+
+#Make it an object of class trajectory:
+cyclicalTrajToy <- defineTrajectories(d = dToy, sites = sitesToy, times = timesToy)
+
+#At this stage, cycles and / or fixed date trajectories are not isolated.
+#This done with the two CETA "extract" functions:
+cyclesToy <- extractCycles(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+fdTrajToy <- extractFixedDateTrajectories(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+
+#The output of these functions can be used as input for other ETA functions to get metrics of interest
+#such as trajectory length:
+trajectoryLengths(x = cyclesToy)
+trajectoryLengths(x = fdTrajToy)
+
+#or distances between trajectories:
+trajectoryDistances(x = cyclesToy)
+trajectoryDistances(x = fdTrajToy)
+
+#In addition CETA adds two additional specific metrics (cycle convexity, and computation of cyclical shifts).
+#For reasons explain above, they require the same inputs as function extractCycles():
+cycleConvexity(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+#By the way, it is expect to get a NA with the first cycle in this example,
+#Cycle convexity cannot be computed right at the start or end of the time series
+cycleShifts(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+#Note that because our cycles are perfectly regular here, the cyclicalShift computed are all 0 (or close because of R's computing approximations)
+
+
+
+}
+\seealso{
+\code{\link{trajectoryCyclicalPlots}}
+}
 \author{
 Nicolas Djeghri, UBO
 

--- a/man/trajectoryCyclicalPlots.Rd
+++ b/man/trajectoryCyclicalPlots.Rd
@@ -62,6 +62,33 @@ The functions \code{cyclePCoA} and \code{fixedDateTrajectoryPCoA} give adapted g
 Function \code{cyclePCoA} handles external and potential interpolated ecological states so that they are correctly taken in account in PCoA (i.e. avoiding duplication, and reducing the influence of interpolated ecological states as much as possible). In case of centered cycles, the influence of these ecological states will grow as they will not correspond to duplications anymore.
 In case of centered cycles, the intended use is to set the parameter \code{centered} to \code{TRUE}.
 }
+\examples{
+#First build a toy dataset
+timesToy <- 0:30 #The sampling times of the time series
+cycleDurationToy <- 10 #The duration of the cycles (i.e. the periodicity of the time series)
+sitesToy <- rep(c("A"),length(timesToy)) #The sites sampled (only one named "A")
+trend <- 0.05 #this term will act as a trend displacing the regular cycles
+
+#Build cyclical data (note that we apply the trend only to x):
+x <- sin((timesToy*2*pi)/cycleDurationToy)+trend*timesToy
+y <- cos((timesToy*2*pi)/cycleDurationToy)
+matToy <- cbind(x,y)
+
+#And express it as a distances:
+dToy <- dist(matToy)
+
+#Make it an object of class trajectory:
+cyclicalTrajToy <- defineTrajectories(d = dToy, sites = sitesToy, times = timesToy)
+
+#And extract the cycles and fixed date trajectories:
+cyclesToy <- extractCycles(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+fdTrajToy <- extractFixedDateTrajectories(x = cyclicalTrajToy, cycleDuration = cycleDurationToy)
+
+#CETA plotting functions take the outputs of CETA extract functions as inputs:
+cyclePCoA(cyclesToy)
+fixedDateTrajectoryPCoA(fdTrajToy)
+
+}
 \seealso{
 \code{\link{trajectoryCyclical}}, \code{\link{cmdscale}}
 }

--- a/man/trajectorySections.Rd
+++ b/man/trajectorySections.Rd
@@ -75,6 +75,48 @@ IMPORTANT: Trajectory sections comprises both "internal" and "external" ecologic
 }
 Special care must also be taken when processing the data through principal coordinate analysis as external ecological states are effectively duplicated or interpolated in the output of \code{extractTrajectorySections}.
 }
+\examples{
+#Description of sites and surveys
+sites <- c("1","1","1","2","2","2")
+surveys <- c(1, 2, 3, 1, 2, 3)
+times <- c(0, 1.5, 3, 0, 1.5, 3)
+  
+#Raw data table
+xy <- matrix(0, nrow=6, ncol=2)
+xy[2,2]<-1
+xy[3,2]<-2
+xy[4:6,1] <- 0.5
+xy[4:6,2] <- xy[1:3,2]
+xy[6,1]<-1
+
+#Draw trajectories
+trajectoryPlot(xy, sites, surveys,  
+               traj.colors = c("black","red"), lwd = 2)
+               
+#Distance matrix
+d <- dist(xy)
+d
+  
+#Trajectory data
+x <- defineTrajectories(d, sites, surveys, times)
+
+#Cutting some trajectory sections in those trajectories
+TrajSec <- extractTrajectorySections(x,
+                                     Traj = c("1","1","2"),
+                                     tstart = c(0,1,0.7),
+                                     tend = c(1.2,2.5,2),
+                                     BCstart = rep("internal",3),
+                                     BCend = rep("internal",3))
+#extractTrajectorySections() works from distances, 
+#for representation using trajectoryPlot(),we must first perform a PCoA:
+Newxy <- cmdscale(TrajSec$d)
+trajectoryPlot(Newxy,
+               sites = TrajSec$metadata$sections,
+               surveys = TrajSec$metadata$surveys,
+               traj.colors = c("black","grey","red"),lwd = 2)
+
+
+}
 \author{
 Nicolas Djeghri, UBO
 

--- a/vignettes/IntroductionCETA.Rmd
+++ b/vignettes/IntroductionCETA.Rmd
@@ -57,7 +57,7 @@ sitesToy <- rep(c("A"),length(timesToy))
 noise <- 0.05
 trend <- 0.05
 
-#Make cyclical data (note that we apply the trend only to x:
+#Make cyclical data (note that we apply the trend only to x):
 x <- sin((timesToy*2*pi)/cycleDurationToy)+rnorm(length(timesToy),mean=0,sd=noise)+trend*timesToy
 y <- cos((timesToy*2*pi)/cycleDurationToy)+rnorm(length(timesToy),mean=0,sd=noise)
 matToy <- cbind(x,y)


### PR DESCRIPTION
CETA documentation now provides examples.
A bug occurring when section overlap was also fixed in extractTrajectorySections. CETA function are unaffected (extractCycles never ask for overlapping cycles).