### PR TITLE
More infos from metrics functions, improved CETA examples + 2 bug fixes

### DIFF
--- a/R/trajectoryCyclical.R
+++ b/R/trajectoryCyclical.R
@@ -514,12 +514,18 @@ cycleMetrics <- function(x,
   internal <- cycles$metadata$internal
   
   siteIDs <- unique(sites)
-  df <-  data.frame(trajectory = siteIDs, n = NA, 
+  df <-  data.frame(trajectory = siteIDs, site = NA,
+                    n = NA, t_start = NA, t_end = NA, 
                     length = NA, mean_speed = NA, mean_angle = NA,
                     convexity = NA, variability = NA)
+  for (i in 1:length(siteIDs)){
+    df$site[i] <-unique(cycles$metadata$sites[sites==siteIDs[i]])
+  }
   for(i in 1:length(siteIDs)) {
     df$n[i] <- sum(sites==siteIDs[i]&internal)
   }
+  df$t_start <- tapply(cycles$metadata$times,sites,min)
+  df$t_end <- tapply(cycles$metadata$times,sites,max)
   df$length <- trajectoryLengths(cycles)$Path
   df$mean_speed <- trajectorySpeeds(cycles)$Path
   df$convexity <- cycleConvexity(x,

--- a/R/trajectoryCyclical.R
+++ b/R/trajectoryCyclical.R
@@ -151,6 +151,12 @@
 #' #Note that because our cycles are perfectly regular here, the cyclicalShift
 #' #computed are all 0 (or close because of R's computing approximations)
 #' 
+#' #Subsetting cycles and fixed date trajectories:
+#' subsetTrajectories(cyclesToy,
+#'                    subtrajectory_selection = "A_C1") 
+#' subsetTrajectories(fdTrajToy,
+#'                    subtrajectory_selection = c("A_fdT_2","A_fdT_4"))
+#'                 
 #' #General metrics describing the geometry of cycles:
 #' cycleMetrics(x = cyclicalTrajToy,
 #'              cycleDuration = cycleDurationToy)

--- a/R/trajectoryCyclicalPlots.R
+++ b/R/trajectoryCyclicalPlots.R
@@ -64,6 +64,11 @@
 #' cyclePCoA(cyclesToy)
 #' fixedDateTrajectoryPCoA(fdTrajToy)
 #' 
+#' #After centering of cycles, set  parameter centered to TRUE in cyclePCoA():
+#' cent_cyclesToy <- centerTrajectories(cyclesToy)
+#' cyclePCoA(cent_cyclesToy, centered = T)
+#' 
+#' 
 #' @rdname trajectoryCyclicalPlots
 #' @param x The full output of function \code{\link{extractCycles}} or \code{\link{extractFixedDateTrajectories}} as appropriate, an object of class \code{\link{cycles}} or \code{\link{fd.trajectories}}.
 #' @param centered Boolean. Have the cycles been centered? Default to FALSE.
@@ -94,7 +99,7 @@ cyclePCoA <- function (x,
     
     metadataD <- x$metadata
     
-  } else{
+  }else{
     selec <- integer(0)
     #this loop will first isolate the non-duplicated external ecological states
     #then it will add the internal ecological states (and removing possible overlap)
@@ -149,7 +154,12 @@ cyclePCoA <- function (x,
       
       timesjinput <- x$metadata$times[cyclejinput]
       
-      selec <- (metadataD$times%in%timesjinput) & sitei
+      if (centered == T){
+        selec <- (metadataD$times%in%timesjinput) & sitei & (metadataD$cycles==j)
+      }else{
+        selec <- (metadataD$times%in%timesjinput) & sitei
+      }
+      
       
       timesj <- metadataD$times[selec]
       xarrows <- xp[selec][order(timesj)]

--- a/man/trajectoryCyclical.Rd
+++ b/man/trajectoryCyclical.Rd
@@ -225,6 +225,12 @@ cycleShifts(x = cyclicalTrajToy,
 #Note that because our cycles are perfectly regular here, the cyclicalShift
 #computed are all 0 (or close because of R's computing approximations)
 
+#Subsetting cycles and fixed date trajectories:
+subsetTrajectories(cyclesToy,
+                   subtrajectory_selection = "A_C1") 
+subsetTrajectories(fdTrajToy,
+                   subtrajectory_selection = c("A_fdT_2","A_fdT_4"))
+                
 #General metrics describing the geometry of cycles:
 cycleMetrics(x = cyclicalTrajToy,
              cycleDuration = cycleDurationToy)

--- a/man/trajectoryCyclicalPlots.Rd
+++ b/man/trajectoryCyclicalPlots.Rd
@@ -99,6 +99,11 @@ fdTrajToy <- extractFixedDateTrajectories(x = cyclicalTrajToy,
 cyclePCoA(cyclesToy)
 fixedDateTrajectoryPCoA(fdTrajToy)
 
+#After centering of cycles, set  parameter centered to TRUE in cyclePCoA():
+cent_cyclesToy <- centerTrajectories(cyclesToy)
+cyclePCoA(cent_cyclesToy, centered = T)
+
+
 }
 \seealso{
 \code{\link{trajectoryCyclical}}, \code{\link{cmdscale}}

--- a/vignettes/IntroductionCETA.Rmd
+++ b/vignettes/IntroductionCETA.Rmd
@@ -434,26 +434,18 @@ There is tendency of fixed-date trajectories to have high directionality and low
 Nonetheless, a metric of peculiar interest in fixed-date trajectories might be convergence:
 ```{r}
 #We will do it for the two sites (NNS and SNS) separately, so lets pull them apart
-SNSfdtraj <- fdtrajNSZoo
-NNSfdtraj <- fdtrajNSZoo
-
-#change the distance matrices
-SNSfdtraj$d <- as.dist(as.matrix(SNSfdtraj$d)[SNSfdtraj$metadata$sites=="SNS",SNSfdtraj$metadata$sites=="SNS"])
-NNSfdtraj$d <- as.dist(as.matrix(NNSfdtraj$d)[NNSfdtraj$metadata$sites=="NNS",NNSfdtraj$metadata$sites=="NNS"])
-
-#change metadata
-SNSfdtraj$metadata <- SNSfdtraj$metadata[SNSfdtraj$metadata$sites=="SNS",]
-NNSfdtraj$metadata <- NNSfdtraj$metadata[NNSfdtraj$metadata$sites=="NNS",]
+SNSfdtraj <- subsetTrajectories(fdtrajNSZoo,site_selection = "SNS")
+NNSfdtraj <- subsetTrajectories(fdtrajNSZoo,site_selection = "NNS")
 
 #Then we need to keep only the years during which the fixed-date trajectories all have associated ecological states (this is because we want to perform a symmetric convergence test)
 selecSNS <- as.numeric(names(which(table(SNSfdtraj$metadata$times-SNSfdtraj$metadata$dates)==12)))
 selecNNS <- as.numeric(names(which(table(NNSfdtraj$metadata$times-NNSfdtraj$metadata$dates)==12)))
 
-#change the distance matrices again
+#change the distance matrices
 SNSfdtraj$d <- as.dist(as.matrix(SNSfdtraj$d)[floor(SNSfdtraj$metadata$times)%in%selecSNS,floor(SNSfdtraj$metadata$times)%in%selecSNS])
 NNSfdtraj$d <- as.dist(as.matrix(NNSfdtraj$d)[floor(NNSfdtraj$metadata$times)%in%selecNNS,floor(NNSfdtraj$metadata$times)%in%selecNNS])
 
-# and change metadata again
+# and change metadata
 SNSfdtraj$metadata <- SNSfdtraj$metadata[floor(SNSfdtraj$metadata$times)%in%selecSNS,]
 NNSfdtraj$metadata <- NNSfdtraj$metadata[floor(NNSfdtraj$metadata$times)%in%selecNNS,]
 

--- a/vignettes/IntroductionCETA.Rmd
+++ b/vignettes/IntroductionCETA.Rmd
@@ -394,7 +394,7 @@ fdtrajZooDir <- trajectoryDirectionality(fdtrajNSZoo)
 
 And put them in a convenient dataframe:
 ```{r}
-#descriptive stats (MAYBE THAT COULD BE DONE AUTOMATICALLY BY extractFixedDateTrajectories???):
+#descriptive stats
 monthFDT <- tapply(fdtrajNSZoo$metadata$dates,fdtrajNSZoo$metadata$fdT,min)
 sitesFDT <- tapply(fdtrajNSZoo$metadata$sites,fdtrajNSZoo$metadata$fdT,unique)
 


### PR DESCRIPTION
Hi Miquel,

Here are the latest changes. Pretty much everything is in the title I hope I haven't broke anything particularly when changing trajectoryWindowMetrics ()!

A choice I made that you may not agree with: the column "site" is added to Metrics functions output only if the trajectory is of class cycles, fd.trajectories or sections. It is absent if it is a normal trajectory (as this would be redundant with the column trajectory).
This is handled by an if statement in the code that can be dismantled if you prefer having 100% the same data frame structure.

