### PR TITLE
Bug fix in Metrics functions

### DIFF
--- a/R/trajectoryCyclical.R
+++ b/R/trajectoryCyclical.R
@@ -528,8 +528,8 @@ cycleMetrics <- function(x,
     df$site[i] <-unique(cycles$metadata$sites[sites==siteIDs[i]])
     df$n[i] <- sum(sites==siteIDs[i]&internal)
   }
-  df$t_start <- tapply(cycles$metadata$times,sites,min)
-  df$t_end <- tapply(cycles$metadata$times,sites,max)
+  df$t_start <- tapply(cycles$metadata$times,sites,min)[siteIDs]
+  df$t_end <- tapply(cycles$metadata$times,sites,max)[siteIDs]
   df$length <- trajectoryLengths(cycles)$Path
   df$mean_speed <- trajectorySpeeds(cycles)$Path
   df$convexity <- cycleConvexity(x,

--- a/R/trajectoryMetrics.R
+++ b/R/trajectoryMetrics.R
@@ -752,8 +752,8 @@ trajectoryMetrics <- function(x, add = TRUE) {
   for(i in 1:length(siteIDs)) {
     df$n[i] <- sum(sites==siteIDs[i])
   }
-  df$t_start <- tapply(x$metadata$times,sites,min)
-  df$t_end <- tapply(x$metadata$times,sites,max)
+  df$t_start <- tapply(x$metadata$times,sites,min)[siteIDs]
+  df$t_end <- tapply(x$metadata$times,sites,max)[siteIDs]
   df$length <- trajectoryLengths(x)$Path
   df$mean_speed <- trajectorySpeeds(x)$Path
   df$mean_angle <- trajectoryAngles(x, add = add)$mean


### PR DESCRIPTION
I found a bug in cycleMetrics() where the times where not correctly ordered in the output. This is because of how tapply in R reorders things.

The same bug was present in trajectoryMetrics()

Both are corrected.

TrajectoryWindowMetrics should not be affected as it does not call tapply.