### PR TITLE
CETA vignette update second-order trajectories

### DIFF
--- a/vignettes/IntroductionCETA.Rmd
+++ b/vignettes/IntroductionCETA.Rmd
@@ -393,7 +393,7 @@ trajectoryPCoA(x_second_order_centered,
                length=0.05)
 legend(x="topleft",col=c("blue","red"),pch=15,unique(northseaZoo$sites))
 ```
-After centering of cycles these trajectories describe change in seasonal dynamics irrespective of the position (i.e. average community composition of the cycles), focussing the analysis on change of shape and size of the cycles.  
+After centering of cycles these trajectories describe change in seasonal dynamics irrespective of the position (i.e. average community composition of the cycles), focusing the analysis on change of shape and size of the cycles.  
 
 ### 3.5 Fixed-date trajectories
 

--- a/vignettes/IntroductionCETA.Rmd
+++ b/vignettes/IntroductionCETA.Rmd
@@ -363,7 +363,7 @@ legend(x="topleft",col=c("blue","red"),pch=15,unique(northseaZoo$sites))
 
 We can see from this graph that the Northern and Southern North Sea present parallel changes in seasonal dynamics while maintaining their differences during the whole time series. An important change seem to have occurred around year 2000 in agreement with previous studies that detected a regime shift around that time.  
 
-You know what's fun? We now have two sets of time-ordered "ecological states" (more ecological dynamics to be fair) defined in a distance matrix. This is all we need to do some trajectory analysis. We can thus perform what we call "second-order" trajectory analysis using the distance between cycles as our distance matrix. We wont go in the details here but here is the corresponding graph as an appetizer:
+You know what's fun? We now have two sets of time-ordered "ecological states" (more ecological dynamics to be fair) defined in a distance matrix. This is all we need to do some trajectory analysis. We can thus perform what we call "second-order" trajectory analysis using the distance between cycles as our distance matrix:
 ```{r fig = TRUE, fig.height=5, fig.width=5, fig.align = "center"}
 x_second_order <- defineTrajectories(d = cyclesZooDistances,
                                      sites = sitesCycles,
@@ -374,7 +374,26 @@ trajectoryPCoA(x_second_order,
 legend(x="topleft",col=c("blue","red"),pch=15,unique(northseaZoo$sites))
 ```
 
-Note that the two PCoA do not represent the same variance on their first and second axes. This is due to differences in the correction method used for negative eigenvalues (ignored in the first case, application of Cailliez correction in the second case).
+However, this is perhaps not the best use of the concept of second-order trajectory analysis. Indeed the trajectories above are in fact very similar to the trajectories obtained by simply joining the center of cycles of cycles (not shown here).  
+Where second-order trajectory analysis may be more precious is when it is used on dissimilarities between centered cycles as such:
+```{r fig = TRUE, fig.height=5, fig.width=5, fig.align = "center"}
+#we first center the cycles
+centered_cyclesNSZoo <- centerTrajectories(cyclesNSZoo)
+
+#then compute distances between centered cycles
+centered_cyclesZooDistances <- trajectoryDistances(centered_cyclesNSZoo)
+
+#before finally making it a trajectory object
+x_second_order_centered <- defineTrajectories(d = centered_cyclesZooDistances,
+                                              sites = sitesCycles,
+                                              surveys = yearCycles)
+#and make a plot:
+trajectoryPCoA(x_second_order_centered,
+               traj.colors=c("blue","red"),
+               length=0.05)
+legend(x="topleft",col=c("blue","red"),pch=15,unique(northseaZoo$sites))
+```
+After centering of cycles these trajectories describe change in seasonal dynamics irrespective of the position (i.e. average community composition of the cycles), focussing the analysis on change of shape and size of the cycles.  
 
 ### 3.5 Fixed-date trajectories
 


### PR DESCRIPTION
A small update of the CETA vignette to better discuss second-order trajectories in relation to the latest tests