### PR TITLE
average mode for cycleShifts

### DIFF
--- a/R/trajectoryCyclical.R
+++ b/R/trajectoryCyclical.R
@@ -42,7 +42,11 @@
 #' The function instead compute the most adapted set of cycles to obtain the metric.
 #' 
 #' 
-#' Note: Function \code{cycleShifts} is computation intensive for large data sets, it may not execute immediately.
+#' **Additional notes on function \code{cycleShifts}:** \code{cycleShifts} can be executed in two modes:\code{"real"} and \code{"average"}.
+#' In \code{"real"} mode, \code{cycleShifts} takes real cycles from the dataset as reference for the computation of cyclical shifts.
+#' In \code{"average"} mode, \code{cycleShifts} takes average cycles computed for the different sites (by calls to function \code{\link{averageTrajectories}}) as reference.
+#' The \code{"real"} mode has the  advantage of using only observed ecological states whereas the \code{"average"} mode is  particularly useful to build time series of cyclical shifts (see CETA vignette).
+#' Note that function \code{cycleShifts} is computation intensive for large data sets, it may not execute immediately.
 #' 
 #' Further information and detailed examples of the use of CETA functions can be found in the associated vignette.
 #' 
@@ -84,8 +88,8 @@
 #'      \item{\code{site}: the site for which each cycle shift has been computed.}
 #'      \item{\code{dateCS}: the date for which a cycle shift has been computed.}
 #'      \item{\code{timeCS}: the time of the ecological state for which a cycle shift has been computed (i.e. the time associated to the projected ecological state).}
-#'      \item{\code{timeRef}: the time associated to the reference ecological state.}
-#'      \item{\code{timeScale}: the time difference between the reference and the projected ecological state.}
+#'      \item{\code{timeRef}: the time associated to the reference ecological state (a name if \code{mode = "average"}).}
+#'      \item{\code{timeScale}: the time difference between the reference and the projected ecological state (\code{NA} if \code{mode = "average"}).}
 #'      \item{\code{cyclicalShift}: the cyclical shift computed (an advance if positive, a delay if negative) in the same units as the times input.}
 #' }
 #' 
@@ -408,12 +412,14 @@ cycleConvexity <- function(x,
 }
 
 #' @rdname trajectoryCyclical
+#' @param mode Either \code{"real"} or \code{"average"}. Should real cycles or an average cycle be used as a reference? Defaults to \code{"real"}. See details.  
 #' @param datesCS An optional vector indicating the dates for which a cyclical shift must be computed. Default to \code{unique(dates)} resulting in the computation of all possible cyclical shifts.
 #' @param centering An optional boolean. Should the cycles be centered before computing cyclical shifts? Defaults to \code{TRUE}.
 #' @param add Flag to indicate that constant values should be added (local transformation) to correct triplets of distance values that do not fulfill the triangle inequality.
 #' @export
 cycleShifts <- function (x,
                          cycleDuration,
+                         mode = "real",
                          dates = NULL,
                          datesCS = NULL,
                          centering = TRUE,
@@ -424,6 +430,7 @@ cycleShifts <- function (x,
   if(inherits(x, "fd.trajectories")) stop("'x' should NOT be of class `fd.trajectories`")
   if(inherits(x, "cycles")) stop("'x' should NOT be of class `cycles`")
   if(inherits(x, "sections")) stop("'x' should NOT be of class `sections`")
+  if((mode!="real") & (mode!="average")) stop("Invalid value for parameter 'mode'")
   
   d <- x$d
   sites <- x$metadata$sites
@@ -452,46 +459,85 @@ cycleShifts <- function (x,
     }
     
     for (j in 1:length(siteIDs)){#This loop goes through the sites (we only compare cyclical shifts from the same sites)
-      siteTag <- which(Cycles$metadata$sites==siteIDs[j])
-      dateTag <- which(Cycles$metadata$dates==i)
-      dateTag <- intersect(siteTag,dateTag)
-      
-      AllRefCycles <- unique(Cycles$metadata$cycles[siteTag])
-      AllRefCycles <- AllRefCycles[1:(length(AllRefCycles)-1)]
-      for (k in AllRefCycles){#This loop goes through all the Cycles that will be used as reference.
-        CrefTag <- which(Cycles$metadata$cycles==k)
-        CrefTag <- CrefTag[order(Cycles$metadata$times[CrefTag])]#this line re-orders the cycle according to its times to be sure its properly represented in trajectoryProjection below
-        drefTag <- dateTag[dateTag%in%CrefTag]#a tag for the reference date
-        dateTag <- dateTag[dateTag>max(CrefTag)]#This line ensures that the date (dateTag) which will be compared to the reference are posterior in time
+      if (mode=="real"){
+        siteTag <- which(Cycles$metadata$sites==siteIDs[j])
+        dateTag <- which(Cycles$metadata$dates==i)
+        dateTag <- intersect(siteTag,dateTag)
         
-        if ((length(drefTag)==1) & (length(dateTag)>0)){#a condition to test if the dates we want to compare exist (i.e. do they have associated ecological states?)
-          #Note: there is no need to reorder the cycles as extractCycles always output them in chronological order for a given site
+        AllRefCycles <- unique(Cycles$metadata$cycles[siteTag])
+        AllRefCycles <- AllRefCycles[1:(length(AllRefCycles)-1)]
+        for (k in AllRefCycles){#This loop goes through all the Cycles that will be used as reference.
+          CrefTag <- which(Cycles$metadata$cycles==k)
+          CrefTag <- CrefTag[order(Cycles$metadata$times[CrefTag])]#this line re-orders the cycle according to its times to be sure its properly represented in trajectoryProjection below
+          drefTag <- dateTag[dateTag%in%CrefTag]#a tag for the reference date
+          dateTag <- dateTag[dateTag>max(CrefTag)]#This line ensures that the date (dateTag) which will be compared to the reference are posterior in time
           
-          #Find out onto which segment of Cref the ecological states of interest are projected
-          projCS <- trajectoryProjection(d=Cycles$d,
-                                         target=dateTag,
-                                         trajectory=CrefTag,
-                                         add=add)
-          
-          segmentsTag <- cbind(CrefTag[projCS$segment],CrefTag[projCS$segment+1],projCS$relativeSegmentPosition)
-          
-          #get the "times" of the projection of the ecological states
-          timesProj <- Cycles$metadata$times[segmentsTag[,1]]+
-            ((Cycles$metadata$times[segmentsTag[,2]]-Cycles$metadata$times[segmentsTag[,1]])*segmentsTag[,3])
-          
-          #get the Cyclical shifts:
-          cyclicalShift <- timesProj-Cycles$metadata$times[drefTag]
-          timeRef <- rep(Cycles$metadata$times[drefTag],length(dateTag))
-          timeCS <- Cycles$metadata$times[dateTag]
-          #Add some "metadata" to accompany Dt
-          PartialOutput <- data.frame(sites = rep(siteIDs[j],length(timeRef)),
-                                      dateCS = rep(i,length(timeRef)),
-                                      timeCS = timeCS,
-                                      timeRef = timeRef,
-                                      timeScale = timeCS - timeRef,
-                                      cyclicalShift = cyclicalShift)
-          Output <- rbind(Output,PartialOutput)
+          if ((length(drefTag)==1) & (length(dateTag)>0)){#a condition to test if the dates we want to compare exist (i.e. do they have associated ecological states?)
+            #Note: there is no need to reorder the cycles as extractCycles always output them in chronological order for a given site
+            
+            #Find out onto which segment of Cref the ecological states of interest are projected
+            projCS <- trajectoryProjection(d=Cycles$d,
+                                           target=dateTag,
+                                           trajectory=CrefTag,
+                                           add=add)
+            
+            segmentsTag <- cbind(CrefTag[projCS$segment],CrefTag[projCS$segment+1],projCS$relativeSegmentPosition)
+            
+            #get the "times" of the projection of the ecological states
+            timesProj <- Cycles$metadata$times[segmentsTag[,1]]+
+              ((Cycles$metadata$times[segmentsTag[,2]]-Cycles$metadata$times[segmentsTag[,1]])*segmentsTag[,3])
+            
+            #get the Cyclical shifts:
+            cyclicalShift <- timesProj-Cycles$metadata$times[drefTag]
+            timeRef <- rep(Cycles$metadata$times[drefTag],length(dateTag))
+            timeCS <- Cycles$metadata$times[dateTag]
+            #Add some "metadata" to accompany the cyclical shifts computed
+            PartialOutput <- data.frame(sites = rep(siteIDs[j],length(timeRef)),
+                                        dateCS = rep(i,length(timeRef)),
+                                        timeCS = timeCS,
+                                        timeRef = timeRef,
+                                        timeScale = timeCS - timeRef,
+                                        cyclicalShift = cyclicalShift)
+            Output <- rbind(Output,PartialOutput)
+          }
         }
+      }else if (mode=="average"){
+        CyclesAV <- subsetTrajectories(Cycles,site_selection = siteIDs[j])
+        
+        nameAV <- paste("average site",siteIDs[j])
+        CyclesAV <- averageTrajectories(CyclesAV,keep_members = TRUE,output_name = nameAV)
+        
+        dateTag <- which((CyclesAV$metadata$dates==i)&(CyclesAV$metadata$cycles!=nameAV))
+        
+        CrefTag <- which(CyclesAV$metadata$cycles==nameAV)
+        CrefTag <- CrefTag[order(CyclesAV$metadata$times[CrefTag])]#this line re-orders the cycle according to its times to be sure its properly represented in trajectoryProjection below
+        drefTag <- which((CyclesAV$metadata$dates==i)&(CyclesAV$metadata$cycles==nameAV))#a tag for the reference date
+        
+        
+        #Find out onto which segment of Cref the ecological states of interest are projected
+        projCS <- trajectoryProjection(d=CyclesAV$d,
+                                       target=dateTag,
+                                       trajectory=CrefTag,
+                                       add=add)
+        
+        segmentsTag <- cbind(CrefTag[projCS$segment],CrefTag[projCS$segment+1],projCS$relativeSegmentPosition)
+        
+        #get the "times" of the projection of the ecological states
+        timesProj <- CyclesAV$metadata$times[segmentsTag[,1]]+
+          ((CyclesAV$metadata$times[segmentsTag[,2]]-CyclesAV$metadata$times[segmentsTag[,1]])*segmentsTag[,3])
+        
+        #get the Cyclical shifts:
+        cyclicalShift <- timesProj-CyclesAV$metadata$times[drefTag]
+        timeRef <- rep(nameAV,length(dateTag))
+        timeCS <- CyclesAV$metadata$times[dateTag]
+        #Add some "metadata" to accompany the cyclical shifts computed
+        PartialOutput <- data.frame(sites = rep(siteIDs[j],length(timeRef)),
+                                    dateCS = rep(i,length(timeRef)),
+                                    timeCS = timeCS,
+                                    timeRef = timeRef,
+                                    timeScale = NA,
+                                    cyclicalShift = cyclicalShift)
+        Output <- rbind(Output,PartialOutput)
       }
     }
   }

--- a/R/transformTrajectories.R
+++ b/R/transformTrajectories.R
@@ -196,6 +196,7 @@ centerTrajectories<-function(x, exclude = integer(0)) {
 averageTrajectories<-function(x, group = NULL, keep_members = FALSE, output_name = "average") {
   if(!inherits(x, "trajectories")) stop("'x' should be of class `trajectories`")
   if(!is.synchronous(x)) stop("Trajectories need to be synchronous for trajectory averaging.")
+  if(sum(x$metadata$sites%in%output_name)>0) stop("'output_name' should not correspond to a site or sub-trajectory name")
   if((length(unique(x$metadata$sites))>1)&
      (inherits(x, "cycles")|inherits(x, "fd.trajectories"))&
      (is.null(group))){
@@ -213,7 +214,7 @@ averageTrajectories<-function(x, group = NULL, keep_members = FALSE, output_name
   } else {
     sites <- x$metadata$sites
   }
-  
+  if(sum(sites%in%output_name)>0) stop("'output_name' should not correspond to a site or sub-trajectory name")
   
   # Check group definition
   if(is.null(group)) {

--- a/R/transformTrajectories.R
+++ b/R/transformTrajectories.R
@@ -291,6 +291,9 @@ averageTrajectories<-function(x, group = NULL, keep_members = FALSE, output_name
     avExt <- which((x$metadata$cycles==output_name)&(x$metadata$internal==FALSE))
     avFirst <- which((x$metadata$cycles==output_name)&(x$metadata$internal==TRUE))[1]
     
+    aver <- which(x$metadata$cycles==output_name)
+    cycleDur <- max(x$metadata$times[aver])-min(x$metadata$times[aver])
+    
     dModif <- as.matrix(x$d)
     dModif <- rbind(cbind(dModif,dModif[avFirst,]),c(dModif[avFirst,],0)) #duplicate first internal state
     dModif <- dModif[-avExt,-avExt]#remove average cycle's external states
@@ -303,7 +306,7 @@ averageTrajectories<-function(x, group = NULL, keep_members = FALSE, output_name
     aver <- which(x$metadata$cycles==output_name)
     x$metadata$surveys[nrow(x$metadata)] <- x$metadata$surveys[nrow(x$metadata)]+max(x$metadata$surveys[aver])
     x$metadata$surveys[aver] <- order(x$metadata$surveys[aver])
-    x$metadata$times[nrow(x$metadata)] <- x$metadata$times[nrow(x$metadata)]+max(x$metadata$times[aver])
+    x$metadata$times[nrow(x$metadata)] <- x$metadata$times[nrow(x$metadata)]+cycleDur
     x$metadata$internal[nrow(x$metadata)] <- FALSE
   }
   

--- a/man/trajectoryCyclical.Rd
+++ b/man/trajectoryCyclical.Rd
@@ -43,6 +43,7 @@ cycleConvexity(
 cycleShifts(
   x,
   cycleDuration,
+  mode = "real",
   dates = NULL,
   datesCS = NULL,
   centering = TRUE,
@@ -78,6 +79,8 @@ cycleMetrics(
 \item{namesFixedDate}{An optional vector of names associated to each \code{fixedDate}. Defaults to \code{round(fixedDate,2)}.}
 
 \item{add}{Flag to indicate that constant values should be added (local transformation) to correct triplets of distance values that do not fulfill the triangle inequality.}
+
+\item{mode}{Either \code{"real"} or \code{"average"}. Should real cycles or an average cycle be used as a reference? Defaults to \code{"real"}. See details.}
 
 \item{datesCS}{An optional vector indicating the dates for which a cyclical shift must be computed. Default to \code{unique(dates)} resulting in the computation of all possible cyclical shifts.}
 
@@ -121,8 +124,8 @@ Function \code{cycleShifts} returns an object of class \code{\link{data.frame}} 
 \item{\code{site}: the site for which each cycle shift has been computed.}
 \item{\code{dateCS}: the date for which a cycle shift has been computed.}
 \item{\code{timeCS}: the time of the ecological state for which a cycle shift has been computed (i.e. the time associated to the projected ecological state).}
-\item{\code{timeRef}: the time associated to the reference ecological state.}
-\item{\code{timeScale}: the time difference between the reference and the projected ecological state.}
+\item{\code{timeRef}: the time associated to the reference ecological state (a name if \code{mode = "average"}).}
+\item{\code{timeScale}: the time difference between the reference and the projected ecological state (\code{NA} if \code{mode = "average"}).}
 \item{\code{cyclicalShift}: the cyclical shift computed (an advance if positive, a delay if negative) in the same units as the times input.}
 }
 
@@ -167,7 +170,11 @@ There is three important exceptions to that rule: the functions \code{cycleConve
 For \code{cycleConvexity}, this is because convexity uses angles obtained from the whole cyclical trajectory, and not only the cycles. For \code{cycleShifts}, this is because cyclical shifts are not obtained with respect to a particular set of cycles. For \code{cycleMetrics}, this is because it calls \code{cycleConvexity}.
 The function instead compute the most adapted set of cycles to obtain the metric.
 
-Note: Function \code{cycleShifts} is computation intensive for large data sets, it may not execute immediately.
+\strong{Additional notes on function \code{cycleShifts}:} \code{cycleShifts} can be executed in two modes:\code{"real"} and \code{"average"}.
+In \code{"real"} mode, \code{cycleShifts} takes real cycles from the dataset as reference for the computation of cyclical shifts.
+In \code{"average"} mode, \code{cycleShifts} takes average cycles computed for the different sites (by calls to function \code{\link{averageTrajectories}}) as reference.
+The \code{"real"} mode has the  advantage of using only observed ecological states whereas the \code{"average"} mode is  particularly useful to build time series of cyclical shifts (see CETA vignette).
+Note that function \code{cycleShifts} is computation intensive for large data sets, it may not execute immediately.
 
 Further information and detailed examples of the use of CETA functions can be found in the associated vignette.
 }

--- a/vignettes/IntroductionCETA.Rmd
+++ b/vignettes/IntroductionCETA.Rmd
@@ -219,7 +219,7 @@ A last novelty of CETA is to provide a way to generalize the concept of phenolog
 ```{r}
 cycleShifts(xToy, cycleDuration = cycleDurationToy)
 ```
-The output gives the `cycleShifts()` computed in the same units as the input `time`, with positive values indicating advance and negative values indicating delay. The other columns give information on what exactly was compared. We will come back to this output in the real example below. 
+The output gives the `cycleShifts()` computed in the same units as the input `time`, with positive values indicating advance and negative values indicating delay. The other columns give information on what exactly was compared. We will come back to this output and explore the two modes of `cycleShifts()` in the real example below. 
 
 ### 2.5 Summary of the CETA approach
 Here is a visual summary of the CETA approach:
@@ -562,3 +562,42 @@ abline(h=0)
 
 The two regions of the North Sea exhibit a similar pattern of cyclical shift: there is maximal advance (positive shift) in spring and autumn. The advance computed is not negligible, communities take around 6 to 12 days of advance every decade at those months (at least in term of composition)!
 
+A legitimate question to ask at this point is: when did those advances or delay happened? With the method illustrated above, we only compute broad trends. It would be nice to compute detailed time series. The problem with cyclical shift, is that we need a reference point. An approach would be to use the first cycle as reference and to only look at the cyclical shifts computed with respect to that cycle. This can be done from the output above but this risks the whole analysis on one cycle that might not be a good reference.
+
+An alternative is to use an average cycle. This is precisely what the parameter `mode` of function `cycleShifts()` allows to do. Let's compute it below for only the month of April (by setting parameter `dateCS`) to reduce computation time.
+```{r}
+#this rather complicated line recovers the date corresponding to april in this dataset:
+April <- unique(x_northseaZoo$metadata$times-floor(x_northseaZoo$metadata$times))[4]
+
+#Note that we set here minEcolStates to 12 to have only complete cycles
+#This is because we need complete trajectories for trajectory averaging
+#(otherwise, the function will throw an error, feel free to try!)
+CSNSZooAVApr <- cycleShifts(x_northseaZoo,
+                            cycleDuration = 1,
+                            minEcolStates = 12,
+                            datesCS = April,
+                            mode="average")
+head(CSNSZooAVApr)
+```
+
+Note that the output is slightly different from what it was in the other mode. `timeScale` now contains `NA`, `timeRef` contains a name corresponding to the average cycle used as reference. This is because the average cycle has no particular position in time making those two metrics irrelevant.
+
+We can then plot cyclical shifts as time series to see period of fast or slow change for the SNS and NNS:
+```{r}
+#Note the multiplication by 365 to get the cyclical shift in days
+plot(x=CSNSZooAVApr$timeCS[CSNSZooAVApr$sites=="SNS"],
+     y=CSNSZooAVApr$cyclicalShift[CSNSZooAVApr$sites=="SNS"]*365,
+     type="b",las=1,
+     ylab="Cyclical shifts (days)",xlab="Year",
+     main="April advances and delays, SNS")
+```
+
+```{r}
+plot(x=CSNSZooAVApr$timeCS[CSNSZooAVApr$sites=="NNS"],
+     y=CSNSZooAVApr$cyclicalShift[CSNSZooAVApr$sites=="NNS"]*365,
+     type="b",las=1,
+     ylab="Cyclical shifts (days)",xlab="Year",
+     main="April advances and delays, NNS")
+```
+
+Both regions show a clear advancing trend, in agreement with the previous analysis. But the SNS seemed like it had more "stepwise" transition than the NNS regarding advances and delays for the month of April at least!


### PR DESCRIPTION
The average mode for cycleShifts is in there 
+
a bug correction in averageTrajectories when computed on cycle (the bug is actually visible with a missing segment in the present vignette about trajecctory transformation).
+
a new error in averageTrajectories in case the name asked already exists
+
an update to the CETA vignette demonstring the new mode of cycleShifts