### PR TITLE
Bug fix in trajectoryConvergence

### DIFF
--- a/R/trajectoryComparison.R
+++ b/R/trajectoryComparison.R
@@ -542,8 +542,10 @@ trajectoryConvergence<-function(x, type = "pairwise.asymmetric", add = TRUE){
   # This allows treating fixed date trajectories as sites for plotting purposes
   if(inherits(x, "fd.trajectories")) {
     sites <- x$metadata$fdT
+    times <- times - x$metadata$dates
   } else if(inherits(x, "cycles")) {
     sites <- x$metadata$cycles
+    times <- x$metadata$dates
   } else if(inherits(x, "sections")) {
     sites <- x$metadata$sections
   } else {


### PR DESCRIPTION
A bug linked to the recent modification of is.synchronous in trajectoryConvergence() when type = "multiple" with fixed-date trajectories was fixed. Now, trajectoryConvergence takes "synchronicity" in fdT as in is.synchronous() (i.e. correcting for the differences in dates that are there by definition)